### PR TITLE
Change naming rule for version variables in config files

### DIFF
--- a/tasks/base/get_materials.yml
+++ b/tasks/base/get_materials.yml
@@ -4,7 +4,7 @@
 - name: download coreos kernel
   get_url:
     url: "{{ url.coreos_kernel_url }}"
-    dest: "files/{{ openshift.version }}/dependencies/{{ config.coreos_kernel }}"
+    dest: "files/{{ openshift.install_version }}/dependencies/{{ config.coreos_kernel }}"
     #checksum: "sha256:{{ url.sha256_dep_url }}"
   register: downloaded_kernel
   until: downloaded_kernel is succeeded
@@ -13,7 +13,7 @@
 - name: download coreos initramfs
   get_url:
     url: "{{ url.coreos_initramfs_url }}"
-    dest: "files/{{ openshift.version }}/dependencies/{{ config.coreos_initramfs }}"
+    dest: "files/{{ openshift.install_version }}/dependencies/{{ config.coreos_initramfs }}"
     #checksum: "sha256:{{ url.sha256_dep_url }}"
   register: downloaded_initramfs
   until: downloaded_initramfs is succeeded
@@ -22,7 +22,7 @@
 - name: download coreos bios
   get_url:
     url: "{{ url.coreos_bios_url }}"
-    dest: "files/{{ openshift.version }}/dependencies/{{ config.coreos_bios }}"
+    dest: "files/{{ openshift.install_version }}/dependencies/{{ config.coreos_bios }}"
     #checksum: "sha256:{{ url.sha256_dep_url }}"
   register: downloaded_bios
   until: downloaded_bios is succeeded
@@ -31,7 +31,7 @@
 - name: download coreos bios signature
   get_url:
     url: "{{ url.coreos_bios_url }}.sig"
-    dest: "files/{{ openshift.version }}/dependencies/{{ config.coreos_bios }}.sig"
+    dest: "files/{{ openshift.install_version }}/dependencies/{{ config.coreos_bios }}.sig"
     #checksum: "sha256:{{ url.sha256_dep_url }}"
   register: downloaded_bios_sig
   until: downloaded_bios_sig is succeeded
@@ -41,7 +41,7 @@
 - name: download openshift installer
   get_url:
     url: "{{ url.openshift_installer_url }}"
-    dest: "files/{{ openshift.version }}/clients/{{ config.openshift_installer }}"
+    dest: "files/{{ openshift.install_version }}/clients/{{ config.openshift_installer }}"
     checksum: "sha256:{{ url.sha256_client_url }}"
   register: downloaded_installer
   until: downloaded_installer is succeeded
@@ -50,7 +50,7 @@
 - name: download openshift client
   get_url:
     url: "{{ url.openshift_client_url }}"
-    dest: "files/{{ openshift.version }}/clients/{{ config.openshift_client }}"
+    dest: "files/{{ openshift.install_version }}/clients/{{ config.openshift_client }}"
     checksum: "sha256:{{ url.sha256_client_url }}"
   register: downloaded_client
   until: downloaded_client is succeeded

--- a/tasks/base/get_materials.yml
+++ b/tasks/base/get_materials.yml
@@ -4,7 +4,7 @@
 - name: download coreos kernel
   get_url:
     url: "{{ url.coreos_kernel_url }}"
-    dest: "files/{{ openshift.install_version }}/dependencies/{{ config.coreos_kernel }}"
+    dest: "{{ files.base }}/dependencies/{{ config.coreos_kernel }}"
     #checksum: "sha256:{{ url.sha256_dep_url }}"
   register: downloaded_kernel
   until: downloaded_kernel is succeeded
@@ -13,7 +13,7 @@
 - name: download coreos initramfs
   get_url:
     url: "{{ url.coreos_initramfs_url }}"
-    dest: "files/{{ openshift.install_version }}/dependencies/{{ config.coreos_initramfs }}"
+    dest: "{{ files.base }}/dependencies/{{ config.coreos_initramfs }}"
     #checksum: "sha256:{{ url.sha256_dep_url }}"
   register: downloaded_initramfs
   until: downloaded_initramfs is succeeded
@@ -22,7 +22,7 @@
 - name: download coreos bios
   get_url:
     url: "{{ url.coreos_bios_url }}"
-    dest: "files/{{ openshift.install_version }}/dependencies/{{ config.coreos_bios }}"
+    dest: "{{ files.base }}/dependencies/{{ config.coreos_bios }}"
     #checksum: "sha256:{{ url.sha256_dep_url }}"
   register: downloaded_bios
   until: downloaded_bios is succeeded
@@ -31,7 +31,7 @@
 - name: download coreos bios signature
   get_url:
     url: "{{ url.coreos_bios_url }}.sig"
-    dest: "files/{{ openshift.install_version }}/dependencies/{{ config.coreos_bios }}.sig"
+    dest: "{{ files.base }}/dependencies/{{ config.coreos_bios }}.sig"
     #checksum: "sha256:{{ url.sha256_dep_url }}"
   register: downloaded_bios_sig
   until: downloaded_bios_sig is succeeded
@@ -41,7 +41,7 @@
 - name: download openshift installer
   get_url:
     url: "{{ url.openshift_installer_url }}"
-    dest: "files/{{ openshift.install_version }}/clients/{{ config.openshift_installer }}"
+    dest: "{{ files.base }}/clients/{{ config.openshift_installer }}"
     checksum: "sha256:{{ url.sha256_client_url }}"
   register: downloaded_installer
   until: downloaded_installer is succeeded
@@ -50,7 +50,7 @@
 - name: download openshift client
   get_url:
     url: "{{ url.openshift_client_url }}"
-    dest: "files/{{ openshift.install_version }}/clients/{{ config.openshift_client }}"
+    dest: "{{ files.base }}/clients/{{ config.openshift_client }}"
     checksum: "sha256:{{ url.sha256_client_url }}"
   register: downloaded_client
   until: downloaded_client is succeeded

--- a/tasks/base/mk_boot-ipxe-cfg.yml
+++ b/tasks/base/mk_boot-ipxe-cfg.yml
@@ -2,7 +2,7 @@
 - name: make ipxe/boot.ipxe.ROLE
   template:
     src:  templates/ipxe/boot-ipxe-cfg.j2
-    dest: "files/{{ openshift.install_version }}/conf/boot.ipxe.{{ item }}"
+    dest: "{{ files.base }}/conf/boot.ipxe.{{ item }}"
   with_items:
     - bootstrap
     - master

--- a/tasks/base/mk_boot-ipxe-cfg.yml
+++ b/tasks/base/mk_boot-ipxe-cfg.yml
@@ -2,7 +2,7 @@
 - name: make ipxe/boot.ipxe.ROLE
   template:
     src:  templates/ipxe/boot-ipxe-cfg.j2
-    dest: "files/{{ openshift.version }}/conf/boot.ipxe.{{ item }}"
+    dest: "files/{{ openshift.install_version }}/conf/boot.ipxe.{{ item }}"
   with_items:
     - bootstrap
     - master

--- a/tasks/base/mk_dnsmasq-conf.yml
+++ b/tasks/base/mk_dnsmasq-conf.yml
@@ -2,9 +2,9 @@
 - name: make dnsmasq/openshift.conf
   template:
     src:  templates/dnsmasq/dnsmasq_conf.j2
-    dest: "files/{{ openshift.version }}/conf/dnsmasq.openshift.conf"
+    dest: "files/{{ openshift.install_version }}/conf/dnsmasq.openshift.conf"
 
 - name: make dnsmasq/hosts.openshift
   template:
     src:  templates/dnsmasq/hosts_openshift.j2
-    dest: "files/{{ openshift.version }}/conf/dnsmasq.hosts.openshift"
+    dest: "files/{{ openshift.install_version }}/conf/dnsmasq.hosts.openshift"

--- a/tasks/base/mk_dnsmasq-conf.yml
+++ b/tasks/base/mk_dnsmasq-conf.yml
@@ -2,9 +2,9 @@
 - name: make dnsmasq/openshift.conf
   template:
     src:  templates/dnsmasq/dnsmasq_conf.j2
-    dest: "files/{{ openshift.install_version }}/conf/dnsmasq.openshift.conf"
+    dest: "{{ files.base }}/conf/dnsmasq.openshift.conf"
 
 - name: make dnsmasq/hosts.openshift
   template:
     src:  templates/dnsmasq/hosts_openshift.j2
-    dest: "files/{{ openshift.install_version }}/conf/dnsmasq.hosts.openshift"
+    dest: "{{ files.base }}/conf/dnsmasq.hosts.openshift"

--- a/tasks/base/mk_files-dir.yml
+++ b/tasks/base/mk_files-dir.yml
@@ -1,20 +1,20 @@
 ---
 - name: make files dir
   file:
-    path: "files/{{ openshift.version }}"
+    path: "files/{{ openshift.install_version }}"
     state: directory
 
 - name: make files/clients dir
   file:
-    path: "files/{{ openshift.version }}/clients"
+    path: "files/{{ openshift.install_version }}/clients"
     state: directory
 
 - name: make files/dependencies dir
   file:
-    path: "files/{{ openshift.version }}/dependencies"
+    path: "files/{{ openshift.install_version }}/dependencies"
     state: directory
 
 - name: make files/conf dir
   file:
-    path: "files/{{ openshift.version }}/conf"
+    path: "files/{{ openshift.install_version }}/conf"
     state: directory

--- a/tasks/base/mk_files-dir.yml
+++ b/tasks/base/mk_files-dir.yml
@@ -1,20 +1,20 @@
 ---
 - name: make files dir
   file:
-    path: "files/{{ openshift.install_version }}"
+    path: "{{ files.base }}"
     state: directory
 
 - name: make files/clients dir
   file:
-    path: "files/{{ openshift.install_version }}/clients"
+    path: "{{ files.base }}/clients"
     state: directory
 
 - name: make files/dependencies dir
   file:
-    path: "files/{{ openshift.install_version }}/dependencies"
+    path: "{{ files.base }}/dependencies"
     state: directory
 
 - name: make files/conf dir
   file:
-    path: "files/{{ openshift.install_version }}/conf"
+    path: "{{ files.base }}/conf"
     state: directory

--- a/tasks/base/mk_libvirtd-conf.yml
+++ b/tasks/base/mk_libvirtd-conf.yml
@@ -2,4 +2,4 @@
 - name: make libvirtd/nat-openshift.conf
   template:
     src:  templates/libvirtd/nat-openshift.j2
-    dest: "files/{{ openshift.version }}/conf/libvirtd.nat-openshift.xml"
+    dest: "files/{{ openshift.install_version }}/conf/libvirtd.nat-openshift.xml"

--- a/tasks/base/mk_libvirtd-conf.yml
+++ b/tasks/base/mk_libvirtd-conf.yml
@@ -2,4 +2,4 @@
 - name: make libvirtd/nat-openshift.conf
   template:
     src:  templates/libvirtd/nat-openshift.j2
-    dest: "files/{{ openshift.install_version }}/conf/libvirtd.nat-openshift.xml"
+    dest: "{{ files.base }}/conf/libvirtd.nat-openshift.xml"

--- a/tasks/base/mk_nginx-conf.yml
+++ b/tasks/base/mk_nginx-conf.yml
@@ -2,4 +2,4 @@
 - name: make nginx/nginx.conf
   template:
     src:  templates/nginx/nginx_conf.j2
-    dest: "files/{{ openshift.install_version }}/conf/nginx.conf"
+    dest: "{{ files.base }}/conf/nginx.conf"

--- a/tasks/base/mk_nginx-conf.yml
+++ b/tasks/base/mk_nginx-conf.yml
@@ -2,4 +2,4 @@
 - name: make nginx/nginx.conf
   template:
     src:  templates/nginx/nginx_conf.j2
-    dest: "files/{{ openshift.version }}/conf/nginx.conf"
+    dest: "files/{{ openshift.install_version }}/conf/nginx.conf"

--- a/tasks/base/mk_openshift-install-config.yml
+++ b/tasks/base/mk_openshift-install-config.yml
@@ -2,4 +2,4 @@
 - name: make bare-metal/install-config.yaml
   template:
     src:  templates/bare-metal/install-config-yaml.j2
-    dest: "files/{{ openshift.install_version }}/conf/install-config.yaml"
+    dest: "{{ files.base }}/conf/install-config.yaml"

--- a/tasks/base/mk_openshift-install-config.yml
+++ b/tasks/base/mk_openshift-install-config.yml
@@ -2,4 +2,4 @@
 - name: make bare-metal/install-config.yaml
   template:
     src:  templates/bare-metal/install-config-yaml.j2
-    dest: "files/{{ openshift.version }}/conf/install-config.yaml"
+    dest: "files/{{ openshift.install_version }}/conf/install-config.yaml"

--- a/tasks/kvm_host/approve-csr.yml
+++ b/tasks/kvm_host/approve-csr.yml
@@ -2,7 +2,7 @@
 - name: check csr status
   command: /root/bin/oc get csr
   environment:
-    KUBECONFIG: /root/openshift-ansible-kvm/bare-metal/auth/kubeconfig
+    KUBECONFIG: "{{ files.kvm }}/bare-metal/auth/kubeconfig"
   register: result
   ignore_errors: yes
 
@@ -10,12 +10,12 @@
   shell: >-
     /root/bin/oc get csr | grep Pending |awk '{ print $1 }'
   environment:
-    KUBECONFIG: /root/openshift-ansible-kvm/bare-metal/auth/kubeconfig
+    KUBECONFIG: "{{ files.kvm }}/bare-metal/auth/kubeconfig"
   register: result
   ignore_errors: yes
 
 - name: approve csr
   command: "/root/bin/oc adm certificate approve {{ item }}"
   environment:
-    KUBECONFIG: /root/openshift-ansible-kvm/bare-metal/auth/kubeconfig
+    KUBECONFIG: "{{ files.kvm }}/bare-metal/auth/kubeconfig"
   with_items: "{{ result.stdout_lines }}"

--- a/tasks/kvm_host/cleanup-all.yaml
+++ b/tasks/kvm_host/cleanup-all.yaml
@@ -64,12 +64,12 @@
 
 - name: check old working dir
   stat:
-    path: "/root/openshift-ansible-kvm"
+    path: "{{ files.kvm }}"
   register: chk_file
 
 - name: remove old working dir
   file:
-    path: /root/openshift-ansible-kvm
+    path: "{{ files.kvm }}"
     state: absent
   when:
     - chk_file.stat.exists == true

--- a/tasks/kvm_host/mk_files-dir.yml
+++ b/tasks/kvm_host/mk_files-dir.yml
@@ -1,5 +1,5 @@
 ---
 - name: make working dir
   file:
-    path: /root/openshift-ansible-kvm
+    path: "{{ files.kvm }}"
     state: directory

--- a/tasks/kvm_host/setup-dnsmasq.yml
+++ b/tasks/kvm_host/setup-dnsmasq.yml
@@ -1,7 +1,7 @@
 ---
 - name: send dnsmasq config to kvm host
   copy:
-    src:  "files/{{ openshift.version }}/conf/dnsmasq.openshift.conf"
+    src:  "files/{{ openshift.install_version }}/conf/dnsmasq.openshift.conf"
     dest: /etc/dnsmasq.d/openshift.conf
     selevel: s0
     serole: object_r
@@ -10,7 +10,7 @@
 
 - name: send dnsmasq hosts to kvm host
   copy:
-    src:  "files/{{ openshift.version }}/conf/dnsmasq.hosts.openshift"
+    src:  "files/{{ openshift.install_version }}/conf/dnsmasq.hosts.openshift"
     dest: /etc/hosts.openshift
     selevel: s0
     serole: object_r

--- a/tasks/kvm_host/setup-dnsmasq.yml
+++ b/tasks/kvm_host/setup-dnsmasq.yml
@@ -1,7 +1,7 @@
 ---
 - name: send dnsmasq config to kvm host
   copy:
-    src:  "files/{{ openshift.install_version }}/conf/dnsmasq.openshift.conf"
+    src:  "{{ files.base }}/conf/dnsmasq.openshift.conf"
     dest: /etc/dnsmasq.d/openshift.conf
     selevel: s0
     serole: object_r
@@ -10,7 +10,7 @@
 
 - name: send dnsmasq hosts to kvm host
   copy:
-    src:  "files/{{ openshift.install_version }}/conf/dnsmasq.hosts.openshift"
+    src:  "{{ files.base }}/conf/dnsmasq.hosts.openshift"
     dest: /etc/hosts.openshift
     selevel: s0
     serole: object_r

--- a/tasks/kvm_host/setup-libvirtd.yml
+++ b/tasks/kvm_host/setup-libvirtd.yml
@@ -25,7 +25,7 @@
   virt_net:
     command: define
     name: openshift
-    xml: "{{lookup('file', 'files/{{ openshift.version }}/conf/libvirtd.nat-openshift.xml')}}"
+    xml: "{{lookup('file', 'files/{{ openshift.install_version }}/conf/libvirtd.nat-openshift.xml')}}"
 
 - name: start openshift nat
   virt_net:

--- a/tasks/kvm_host/setup-libvirtd.yml
+++ b/tasks/kvm_host/setup-libvirtd.yml
@@ -25,7 +25,7 @@
   virt_net:
     command: define
     name: openshift
-    xml: "{{lookup('file', 'files/{{ openshift.install_version }}/conf/libvirtd.nat-openshift.xml')}}"
+    xml: "{{lookup('file', '{{ files.base }}/conf/libvirtd.nat-openshift.xml')}}"
 
 - name: start openshift nat
   virt_net:

--- a/tasks/kvm_host/setup-nginx.yml
+++ b/tasks/kvm_host/setup-nginx.yml
@@ -1,7 +1,7 @@
 ---
 - name: send nginx config to kvm host
   copy:
-    src:  "files/{{ openshift.version }}/conf/nginx.conf"
+    src:  "files/{{ openshift.install_version }}/conf/nginx.conf"
     dest: /etc/nginx/nginx.conf
     selevel: s0
     serole: object_r
@@ -32,7 +32,7 @@
 
 - name: send coreos to kvm host
   copy:
-    src:  "files/{{ openshift.version }}/dependencies/{{ item }}"
+    src:  "files/{{ openshift.install_version }}/dependencies/{{ item }}"
     dest: /usr/share/nginx/html/ipxe/
     selevel: s0
     serole: object_r
@@ -46,7 +46,7 @@
 
 - name: send coreos signature to kvm host
   copy:
-    src:  "files/{{ openshift.version }}/dependencies/{{ config.coreos_bios }}.sig"
+    src:  "files/{{ openshift.install_version }}/dependencies/{{ config.coreos_bios }}.sig"
     dest: /usr/share/nginx/html/ipxe/
     selevel: s0
     serole: object_r
@@ -56,7 +56,7 @@
 
 - name: send coreos to kvm host
   copy:
-    src:  "files/{{ openshift.version }}/conf/{{ item }}"
+    src:  "files/{{ openshift.install_version }}/conf/{{ item }}"
     dest: /usr/share/nginx/html/ipxe/
     selevel: s0
     serole: object_r

--- a/tasks/kvm_host/setup-nginx.yml
+++ b/tasks/kvm_host/setup-nginx.yml
@@ -1,7 +1,7 @@
 ---
 - name: send nginx config to kvm host
   copy:
-    src:  "files/{{ openshift.install_version }}/conf/nginx.conf"
+    src:  "{{ files.base }}/conf/nginx.conf"
     dest: /etc/nginx/nginx.conf
     selevel: s0
     serole: object_r
@@ -32,7 +32,7 @@
 
 - name: send coreos to kvm host
   copy:
-    src:  "files/{{ openshift.install_version }}/dependencies/{{ item }}"
+    src:  "{{ files.base }}/dependencies/{{ item }}"
     dest: /usr/share/nginx/html/ipxe/
     selevel: s0
     serole: object_r
@@ -46,7 +46,7 @@
 
 - name: send coreos signature to kvm host
   copy:
-    src:  "files/{{ openshift.install_version }}/dependencies/{{ config.coreos_bios }}.sig"
+    src:  "{{ files.base }}/dependencies/{{ config.coreos_bios }}.sig"
     dest: /usr/share/nginx/html/ipxe/
     selevel: s0
     serole: object_r
@@ -56,7 +56,7 @@
 
 - name: send coreos to kvm host
   copy:
-    src:  "files/{{ openshift.install_version }}/conf/{{ item }}"
+    src:  "{{ files.base }}/conf/{{ item }}"
     dest: /usr/share/nginx/html/ipxe/
     selevel: s0
     serole: object_r

--- a/tasks/kvm_host/setup-openshift-install-config.yml
+++ b/tasks/kvm_host/setup-openshift-install-config.yml
@@ -22,18 +22,18 @@
 
 - name: send install-config.yaml to kvm host
   copy:
-    src:  "files/{{ openshift.version }}/conf/install-config.yaml"
+    src:  "files/{{ openshift.install_version }}/conf/install-config.yaml"
     dest: /root/openshift-ansible-kvm/bare-metal
 
 - name: send openshift installer
   unarchive:
-    src: "files/{{ openshift.version }}/clients/{{ config.openshift_installer }}"
+    src: "files/{{ openshift.install_version }}/clients/{{ config.openshift_installer }}"
     dest: /root/bin
     exclude: README.md
 
 - name: send openshift clients
   unarchive:
-    src: "files/{{ openshift.version }}/clients/{{ config.openshift_client }}"
+    src: "files/{{ openshift.install_version }}/clients/{{ config.openshift_client }}"
     dest: /root/bin
     exclude: README.md
 

--- a/tasks/kvm_host/setup-openshift-install-config.yml
+++ b/tasks/kvm_host/setup-openshift-install-config.yml
@@ -6,43 +6,43 @@
 
 - name: check old bare-metal dir
   stat:
-    path: "/root/openshift-ansible-kvm/bare-metal"
+    path: "{{ files.kvm }}/bare-metal"
   register: chk_file
 
 - name: remove old bare-metal dir
   file:
-    path: /root/openshift-ansible-kvm/bare-metal
+    path: "{{ files.kvm }}/bare-metal"
     state: absent
   when: chk_file.stat.exists == true
 
 - name: make bare-metal dir
   file:
-    path: /root/openshift-ansible-kvm/bare-metal
+    path: "{{ files.kvm }}/bare-metal"
     state: directory
 
 - name: send install-config.yaml to kvm host
   copy:
-    src:  "files/{{ openshift.install_version }}/conf/install-config.yaml"
-    dest: /root/openshift-ansible-kvm/bare-metal
+    src:  "{{ files.base }}/conf/install-config.yaml"
+    dest: "{{ files.kvm }}/bare-metal"
 
 - name: send openshift installer
   unarchive:
-    src: "files/{{ openshift.install_version }}/clients/{{ config.openshift_installer }}"
+    src: "{{ files.base }}/clients/{{ config.openshift_installer }}"
     dest: /root/bin
     exclude: README.md
 
 - name: send openshift clients
   unarchive:
-    src: "files/{{ openshift.install_version }}/clients/{{ config.openshift_client }}"
+    src: "{{ files.base }}/clients/{{ config.openshift_client }}"
     dest: /root/bin
     exclude: README.md
 
 - name: create ignition-configs
-  command: /root/bin/openshift-install create ignition-configs --dir=/root/openshift-ansible-kvm/bare-metal
+  command: "/root/bin/openshift-install create ignition-configs --dir={{ files.kvm }}/bare-metal"
 
 - name: copy ign files
   copy:
-    src:  /root/openshift-ansible-kvm/bare-metal/{{ item }}
+    src:  "{{ files.kvm }}/bare-metal/{{ item }}"
     dest: /usr/share/nginx/html/openshift/coreos/ignitions
     selevel: s0
     serole: object_r

--- a/tasks/kvm_host/wait-for-complete.yml
+++ b/tasks/kvm_host/wait-for-complete.yml
@@ -2,13 +2,13 @@
 - name: fetch kubeadmin-password from kvm host
   fetch:
     src:  /root/openshift-ansible-kvm/bare-metal/auth/kubeadmin-password
-    dest: files/{{ openshift.version }}/conf/
+    dest: files/{{ openshift.install_version }}/conf/
     flat: yes
 
 - name: fetch kubeconfig from kvm host
   fetch:
     src:  /root/openshift-ansible-kvm/bare-metal/auth/kubeconfig
-    dest: files/{{ openshift.version }}/conf/
+    dest: files/{{ openshift.install_version }}/conf/
     flat: yes
 
 - name: wait-for bootstrap-complete

--- a/tasks/kvm_host/wait-for-complete.yml
+++ b/tasks/kvm_host/wait-for-complete.yml
@@ -1,18 +1,18 @@
 ---
 - name: fetch kubeadmin-password from kvm host
   fetch:
-    src:  /root/openshift-ansible-kvm/bare-metal/auth/kubeadmin-password
-    dest: files/{{ openshift.install_version }}/conf/
+    src:  "{{ files.kvm }}/bare-metal/auth/kubeadmin-password"
+    dest: "{{ files.base }}/conf/"
     flat: yes
 
 - name: fetch kubeconfig from kvm host
   fetch:
-    src:  /root/openshift-ansible-kvm/bare-metal/auth/kubeconfig
-    dest: files/{{ openshift.install_version }}/conf/
+    src:  "{{ files.kvm }}/bare-metal/auth/kubeconfig"
+    dest: "{{ files.base }}/conf/"
     flat: yes
 
 - name: wait-for bootstrap-complete
-  command: /root/bin/openshift-install --dir=/root/openshift-ansible-kvm/bare-metal wait-for bootstrap-complete
+  command: "/root/bin/openshift-install --dir={{ files.kvm }}/bare-metal wait-for bootstrap-complete"
   async: 3600
   poll: 0
   register: bootstrap_complete_sleeper
@@ -28,14 +28,14 @@
 - name: oc path to configs.imageregistry.operator.openshift.io/cluster
   command: /root/bin/oc patch configs.imageregistry.operator.openshift.io/cluster --type merge --patch '{"spec":{"storage":{"emptyDir":{}}}}'
   environment:
-    KUBECONFIG: /root/openshift-ansible-kvm/bare-metal/auth/kubeconfig
+    KUBECONFIG: "{{ files.kvm }}/bare-metal/auth/kubeconfig"
   retries: 100
   delay: 10
   register: result
   until: result is not failed
 
 - name: wait-for install-complete
-  command: /root/bin/openshift-install --dir=/root/openshift-ansible-kvm/bare-metal wait-for install-complete
+  command: "/root/bin/openshift-install --dir={{ files.kvm }}/bare-metal wait-for install-complete"
   async: 3600
   poll: 0
   register: install_complete_sleeper
@@ -50,7 +50,7 @@
 
 - name: check kubeadmin-password
   slurp:
-    src: /root/openshift-ansible-kvm/bare-metal/auth/kubeadmin-password
+    src: "{{ files.kvm }}/bare-metal/auth/kubeadmin-password"
   register: kubeadmin_password
 
 - name: show kubeadmin-password

--- a/vars/config.yml.sample
+++ b/vars/config.yml.sample
@@ -20,7 +20,7 @@ kvm_host:
 #  install_version: 4.3.29
 #  coreos_version:  4.3.8
 # --- OCP 4.4 -------------
-#  install_version: 4.4.14
+#  install_version: 4.4.13
 #  coreos_version:  4.4.3
 # --- OCO 4.5 -------------
 #  install_version: 4.5.2
@@ -31,8 +31,8 @@ kvm_host:
 # -------------------------
 openshift:
   dist: ocp
-  coreos_version:  4.5.2
   install_version: 4.5.2
+  coreos_version:  4.5.2
 
 # pullsecret: '{"auths":{"cloud.openshift.com"......}}'
 # sshkey: 'ssh-rsa AAAABBB.....'
@@ -47,5 +47,5 @@ key:
 #    false: stay old files
 cleanup:
   conf: true
-  bin: false
+  bin:  false
 

--- a/vars/config.yml.sample
+++ b/vars/config.yml.sample
@@ -6,33 +6,33 @@ kvm_host:
   if: <IF name>
 
 # OpenShift environment settings
-#  dist: Select a distribution to deploy "ocp" or "okd"
-# --- OCP 4.2 -----------
-#  version: 4.2.0
-#  version_dir: 4.2/4.2.0
-#  latest_version: 4.2.16
-# --- OCP 4.3 -----------
-#  version: 4.3.0
-#  version_dir: 4.3/4.3.0
-#  latest_version: 4.3.0
-# --- OCP 4.4 -----------
-#  version: 4.4.3
-#  version_dir: 4.4/4.4.3
-#  latest_version: 4.4.11
-# --- OCO 4.5 -----------
-#  version: 4.5.2
-#  version_dir: 4.5/4.5.2
-#  latest_version: 4.5.2
-# --- OKD 4 --------------
-#  version: 32.20200629.3.0
-#  version_dir: 
-#  latest_version: 4.5.0-0.okd-2020-07-14-153706-ga
-# ------------------------
+#  dist:            Select the distribution to deploy "ocp" or "okd"
+#  install_version: openshift-install and openshift-client version.
+#    ocp: https://mirror.openshift.com/pub/openshift-v4/clients/ocp/
+#    okd: https://github.com/openshift/okd/releases
+#  coreos_version:  CoreOS version
+#    ocp: https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/
+#    okd: https://getfedora.org/en/coreos/download?tab=metal_virtualized&stream=stable
+# --- OCP 4.2 -------------
+#  install_version: 4.2.36
+#  coreos_version:  4.2.18
+# --- OCP 4.3 -------------
+#  install_version: 4.3.29
+#  coreos_version:  4.3.8
+# --- OCP 4.4 -------------
+#  install_version: 4.4.14
+#  coreos_version:  4.4.3
+# --- OCO 4.5 -------------
+#  install_version: 4.5.2
+#  coreos_version:  4.5.2
+# --- OKD 4 ---------------
+#  install_version: 4.5.0-0.okd-2020-07-14-153706-ga
+#  coreos_version:  32.20200629.3.0
+# -------------------------
 openshift:
   dist: ocp
-  version: 4.5.2
-  version_dir: 4.5/4.5.2
-  latest_version: 4.5.2
+  coreos_version:  4.5.2
+  install_version: 4.5.2
 
 # pullsecret: '{"auths":{"cloud.openshift.com"......}}'
 # sshkey: 'ssh-rsa AAAABBB.....'

--- a/vars/download.yml
+++ b/vars/download.yml
@@ -6,30 +6,34 @@
 version:
   minor: "{{ openshift.coreos_version | regex_replace('^(\\d*\\.\\d*)\\.\\d*','\\1') }}"
 
+# Download path
+files:
+  base: "files/{{ openshift.dist }}/{{ openshift.install_version }}"
+  kvm:  "/root/openshift-ansible-kvm"
+
 # Download URLs
 # kernel
-# for 4.2, 4.3: rhcos-{{ openshift.coreos_version }}-x86_64-installer-kernel
-# for 4.4, 4.5: rhcos-{{ openshift.coreos_version }}-x86_64-installer-kernel-x86_64
+#  for 4.2:     rhcos-{{ openshift.coreos_version }}-x86_64-installer-kernel
+#  for 4.3-4.5: rhcos-{{ openshift.coreos_version }}-x86_64-installer-kernel-x86_64
+#  for okd:     fedora-coreos-{{ openshift.coreos_version }}-live-kernel-x86_64
 # initramfs
-# for 4.2, 4.3: rhcos-{{ openshift.coreos_version }}-x86_64-installer-initramfs.img
-# for 4.4, 4.5: rhcos-{{ openshift.coreos_version }}-x86_64-installer-initramfs.x86_64.img
+#  for 4.2:     rhcos-{{ openshift.coreos_version }}-x86_64-installer-initramfs.img
+#  for 4.3-4.5: rhcos-{{ openshift.coreos_version }}-x86_64-installer-initramfs.x86_64.img
+#  for okd:     fedora-coreos-{{ openshift.coreos_version }}-live-initramfs.x86_64.img
 # bios
-# for 4.2:      rhcos-{{ openshift.coreos_version }}-x86_64-metal-bios.raw.gz
-# for 4.3:      rhcos-{{ openshift.coreos_version }}-x86_64-metal.raw.gz
-# for 4.4, 4.5: rhcos-{{ openshift.coreos_version }}-x86_64-metal.x86_64.raw.gz
-# coreos_kernel:    "rhcos-{{ openshift.coreos_version }}-x86_64-installer-kernel-x86_64"
-# coreos_initramfs: "rhcos-{{ openshift.coreos_version }}-x86_64-installer-initramfs.x86_64.img"
-# coreos_bios:      "rhcos-{{ openshift.coreos_version }}-x86_64-metal.x86_64.raw.gz"
+#  for 4.2:     rhcos-{{ openshift.coreos_version }}-x86_64-metal-bios.raw.gz
+#  for 4.4-4.5: rhcos-{{ openshift.coreos_version }}-x86_64-metal.x86_64.raw.gz
+#  for okd:     fedora-coreos-{{ openshift.coreos_version }}-metal.x86_64.raw.xz
 config:
   coreos_kernel: >-
     {%- if   openshift.dist == 'okd' -%}                                   fedora-coreos-{{ openshift.coreos_version }}-live-kernel-x86_64
-    {%- elif openshift.coreos_version | regex_search("^4\.2\.") -%} rhcos-{{ openshift.coreos_version }}-x86_64-installer-kernel
+    {%- elif openshift.coreos_version | regex_search("^4\.2\.") -%}        rhcos-{{ openshift.coreos_version }}-x86_64-installer-kernel
     {%- elif openshift.coreos_version | regex_search("^4\.+([3-5])\.") -%} rhcos-{{ openshift.coreos_version }}-x86_64-installer-kernel-x86_64
     {%- else -%}                                                           rhcos-{{ openshift.coreos_version }}-x86_64-installer-kernel-x86_64
     {%- endif -%}
   coreos_initramfs: >-
     {%- if   openshift.dist == 'okd' -%}                                   fedora-coreos-{{ openshift.coreos_version }}-live-initramfs.x86_64.img
-    {%- elif openshift.coreos_version | regex_search("^4\.2\.") -%} rhcos-{{ openshift.coreos_version }}-x86_64-installer-initramfs.img
+    {%- elif openshift.coreos_version | regex_search("^4\.2\.") -%}        rhcos-{{ openshift.coreos_version }}-x86_64-installer-initramfs.img
     {%- elif openshift.coreos_version | regex_search("^4\.+([4-5])\.") -%} rhcos-{{ openshift.coreos_version }}-x86_64-installer-initramfs.x86_64.img
     {%- else -%}                                                           rhcos-{{ openshift.coreos_version }}-x86_64-installer-initramfs.x86_64.img
     {%- endif -%}

--- a/vars/download.yml
+++ b/vars/download.yml
@@ -1,40 +1,58 @@
 ---
+# version e.g.
+#   openshift.install_version = 4.4.11
+#   openshift.coreos_version  = 4.4.3
+#   version.minor             = 4.4
+version:
+  minor: "{{ openshift.coreos_version | regex_replace('^(\\d*\\.\\d*)\\.\\d*','\\1') }}"
+
 # Download URLs
 # kernel
-# for 4.2, 4.3: rhcos-{{ openshift.version }}-x86_64-installer-kernel
-# for 4.4, 4.5: rhcos-{{ openshift.version }}-x86_64-installer-kernel-x86_64
+# for 4.2, 4.3: rhcos-{{ openshift.coreos_version }}-x86_64-installer-kernel
+# for 4.4, 4.5: rhcos-{{ openshift.coreos_version }}-x86_64-installer-kernel-x86_64
 # initramfs
-# for 4.2, 4.3: rhcos-{{ openshift.version }}-x86_64-installer-initramfs.img
-# for 4.4, 4.5: rhcos-{{ openshift.version }}-x86_64-installer-initramfs.x86_64.img
+# for 4.2, 4.3: rhcos-{{ openshift.coreos_version }}-x86_64-installer-initramfs.img
+# for 4.4, 4.5: rhcos-{{ openshift.coreos_version }}-x86_64-installer-initramfs.x86_64.img
 # bios
-# for 4.2:      rhcos-{{ openshift.version }}-x86_64-metal-bios.raw.gz
-# for 4.3:      rhcos-{{ openshift.version }}-x86_64-metal.raw.gz
-# for 4.4, 4.5: rhcos-{{ openshift.version }}-x86_64-metal.x86_64.raw.gz
+# for 4.2:      rhcos-{{ openshift.coreos_version }}-x86_64-metal-bios.raw.gz
+# for 4.3:      rhcos-{{ openshift.coreos_version }}-x86_64-metal.raw.gz
+# for 4.4, 4.5: rhcos-{{ openshift.coreos_version }}-x86_64-metal.x86_64.raw.gz
+# coreos_kernel:    "rhcos-{{ openshift.coreos_version }}-x86_64-installer-kernel-x86_64"
+# coreos_initramfs: "rhcos-{{ openshift.coreos_version }}-x86_64-installer-initramfs.x86_64.img"
+# coreos_bios:      "rhcos-{{ openshift.coreos_version }}-x86_64-metal.x86_64.raw.gz"
 config:
-  # coreos_kernel:    "rhcos-{{ openshift.version }}-x86_64-installer-kernel-x86_64"
-  # coreos_initramfs: "rhcos-{{ openshift.version }}-x86_64-installer-initramfs.x86_64.img"
-  # coreos_bios:      "rhcos-{{ openshift.version }}-x86_64-metal.x86_64.raw.gz"
   coreos_kernel: >-
-    {%- if   openshift.dist == 'okd' -%}                            fedora-coreos-{{ openshift.version }}-live-kernel-x86_64
-    {%- elif openshift.version | regex_search("^4\.+([2-3])\.") -%} rhcos-{{ openshift.version }}-x86_64-installer-kernel
-    {%- elif openshift.version | regex_search("^4\.+([4-5])\.") -%} rhcos-{{ openshift.version }}-x86_64-installer-kernel-x86_64
-    {%- else -%}                                                    rhcos-{{ openshift.version }}-x86_64-installer-kernel-x86_64
+    {%- if   openshift.dist == 'okd' -%}                                   fedora-coreos-{{ openshift.coreos_version }}-live-kernel-x86_64
+    {%- elif openshift.coreos_version | regex_search("^4\.2\.") -%} rhcos-{{ openshift.coreos_version }}-x86_64-installer-kernel
+    {%- elif openshift.coreos_version | regex_search("^4\.+([3-5])\.") -%} rhcos-{{ openshift.coreos_version }}-x86_64-installer-kernel-x86_64
+    {%- else -%}                                                           rhcos-{{ openshift.coreos_version }}-x86_64-installer-kernel-x86_64
     {%- endif -%}
   coreos_initramfs: >-
-    {%- if   openshift.dist == 'okd' -%}                            fedora-coreos-{{ openshift.version }}-live-initramfs.x86_64.img
-    {%- elif openshift.version | regex_search("^4\.+([2-3])\.") -%} rhcos-{{ openshift.version }}-x86_64-installer-initramfs.img
-    {%- elif openshift.version | regex_search("^4\.+([4-5])\.") -%} rhcos-{{ openshift.version }}-x86_64-installer-initramfs.x86_64.img
-    {%- else -%}                                                    rhcos-{{ openshift.version }}-x86_64-installer-initramfs.x86_64.img
+    {%- if   openshift.dist == 'okd' -%}                                   fedora-coreos-{{ openshift.coreos_version }}-live-initramfs.x86_64.img
+    {%- elif openshift.coreos_version | regex_search("^4\.2\.") -%} rhcos-{{ openshift.coreos_version }}-x86_64-installer-initramfs.img
+    {%- elif openshift.coreos_version | regex_search("^4\.+([4-5])\.") -%} rhcos-{{ openshift.coreos_version }}-x86_64-installer-initramfs.x86_64.img
+    {%- else -%}                                                           rhcos-{{ openshift.coreos_version }}-x86_64-installer-initramfs.x86_64.img
     {%- endif -%}
   coreos_bios: >-
-    {%- if   openshift.dist == 'okd' -%}                            fedora-coreos-{{ openshift.version }}-metal.x86_64.raw.xz
-    {%- elif openshift.version | regex_search("^4\.2\.") -%}        rhcos-{{ openshift.version }}-x86_64-metal-bios.raw.gz
-    {%- elif openshift.version | regex_search("^4\.3\.") -%}        rhcos-{{ openshift.version }}-x86_64-metal.raw.gz
-    {%- elif openshift.version | regex_search("^4\.+([4-5])\.") -%} rhcos-{{ openshift.version }}-x86_64-metal.x86_64.raw.gz
-    {%- else -%}                                                    rhcos-{{ openshift.version }}-x86_64-metal.x86_64.raw.gz
+    {%- if   openshift.dist == 'okd' -%}                                   fedora-coreos-{{ openshift.coreos_version }}-metal.x86_64.raw.xz
+    {%- elif openshift.coreos_version | regex_search("^4\.2\.") -%}        rhcos-{{ openshift.coreos_version }}-x86_64-metal-bios.raw.gz
+    {%- elif openshift.coreos_version | regex_search("^4\.+([3-5])\.") -%} rhcos-{{ openshift.coreos_version }}-x86_64-metal.x86_64.raw.gz
+    {%- else -%}                                                           rhcos-{{ openshift.coreos_version }}-x86_64-metal.x86_64.raw.gz
     {%- endif -%}
-  openshift_installer: "openshift-install-linux-{{ openshift.latest_version }}.tar.gz"
-  openshift_client:    "openshift-client-linux-{{ openshift.latest_version }}.tar.gz"
+  openshift_installer: "openshift-install-linux-{{ openshift.install_version }}.tar.gz"
+  openshift_client:    "openshift-client-linux-{{ openshift.install_version }}.tar.gz"
+
+static:
+  coreos_base_url: >-
+    {%- if   openshift.dist == 'okd' -%} https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/{{ openshift.coreos_version }}/x86_64
+    {%- elif openshift.dist == 'ocp' -%} https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/{{ version.minor }}/{{ openshift.coreos_version }}
+    {%- else -%}                         https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/{{ version.minor }}/{{ openshift.coreos_version }}
+    {%- endif -%}
+  clients_base_url: >-
+    {%- if   openshift.dist == 'okd' -%} https://github.com/openshift/okd/releases/download/{{ openshift.install_version }}
+    {%- elif openshift.dist == 'ocp' -%} https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ openshift.install_version }}
+    {%- else -%}                         https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ openshift.install_version }}
+    {%- endif -%}
 
 url:
   coreos_kernel_url:       "{{ static.coreos_base_url }}/{{ config.coreos_kernel  }}"
@@ -44,16 +62,4 @@ url:
   openshift_client_url:    "{{ static.clients_base_url }}/{{ config.openshift_client }}"
   sha256_dep_url:          "{{ static.coreos_base_url }}/sha256sum.txt"
   sha256_client_url:       "{{ static.clients_base_url }}/sha256sum.txt"
-
-static:
-  coreos_base_url: >-
-    {%- if   openshift.dist == 'okd' -%} https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/{{ openshift.version }}/x86_64
-    {%- elif openshift.dist == 'ocp' -%} https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/{{ openshift.version_dir }}
-    {%- else -%}                         https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/{{ openshift.version_dir }}
-    {%- endif -%}
-  clients_base_url: >-
-    {%- if   openshift.dist == 'okd' -%} https://github.com/openshift/okd/releases/download/{{ openshift.latest_version }}
-    {%- elif openshift.dist == 'ocp' -%} https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ openshift.latest_version }}
-    {%- else -%}                         https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ openshift.latest_version }}
-    {%- endif -%}
 


### PR DESCRIPTION
- all: Make users able to edit the working directory
- all: Change naming rule for version variables in config files

 
- old:
  - openshift.version
  - openshift.version_dir
  - openshift.latest_version
- new:
  - openshift.coreos_version
  - openshift.install_version