### PR TITLE
kvm: explicitly configure DNS to eliminate DNS instability.

### DIFF
--- a/templates/libvirtd/nat-openshift.j2
+++ b/templates/libvirtd/nat-openshift.j2
@@ -7,7 +7,14 @@
     </nat>
     <interface dev='{{ kvm_host.if }}'/>
   </forward>
-  <ip address='{{ libvirt_nat.router }}' netmask='{{ libvirt_nat.netmask }}'>
+{% if ext_dns==true %}
+  <dns>
+{% for dns in ext_dns %}
+    <forwarder domain='{{ dns.domain }}' addr="{{ dns.addr }}"/>
+{% endfor %}
+  </dns>
+{% endif %}
+<ip address='{{ libvirt_nat.router }}' netmask='{{ libvirt_nat.netmask }}'>
     <dhcp>
       <range start='{{libvirt_nat.dhcp_start }}' end='{{libvirt_nat.dhcp_end }}'/>
       <bootp file='http://{{ libvirt_nat.router }}:8000/ipxe/boot.ipxe'/>

--- a/vars/config.yml.sample
+++ b/vars/config.yml.sample
@@ -56,3 +56,6 @@ cleanup:
   conf: true
   bin:  false
 
+# DNS hack for libvirt
+# Hack for internet connection issues with tricky DNS provided by libvirt+dnsmasq
+use_ext_dns: false

--- a/vars/download.yml
+++ b/vars/download.yml
@@ -109,3 +109,20 @@ url:
     {%- else -%}                         {{ static.coreos_base_url }}/sha256sum.txt
     {%- endif -%}
   sha256_client_url:       "{{ static.clients_base_url }}/sha256sum.txt"
+
+
+# DNS hack for libvirt
+# Hack for internet connection issues with tricky DNS provided by libvirt+dnsmasq
+ext_dns:
+  - domain: "openshift.com"
+    addr: "8.8.8.8"
+  - domain: "quay.io"
+    addr: "8.8.8.8"
+  - domain: "redhat.com"
+    addr: "8.8.8.8"
+  - domain: "redhat.io"
+    addr: "8.8.8.8"
+  - domain: "amazonaws.com"
+    addr: "8.8.8.8"
+  - domain: "docker.io"
+    addr: "8.8.8.8"


### PR DESCRIPTION
Add DNS hack for libvirt.

Signed-off-by: Kazuhisa Hara <kahara@redhat.com>