### PR TITLE
Fix unknown directive stream in nginx

### DIFF
--- a/main-minimal.yml
+++ b/main-minimal.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: base
+  gather_facts: yes
   vars_files:
     - vars/config.yml
     - vars/vm_setting.yml
@@ -15,6 +16,7 @@
     - include_tasks: tasks/base/get_materials.yml
 
 - hosts: kvm_host
+  gather_facts: yes
   vars_files:
     - vars/config.yml
     - vars/vm_setting.yml

--- a/main.yml
+++ b/main.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: base
+  gather_facts: yes
   vars_files:
     - vars/config.yml
     - vars/vm_setting.yml
@@ -15,6 +16,7 @@
     - include_tasks: tasks/base/get_materials.yml
 
 - hosts: kvm_host
+  gather_facts: yes
   vars_files:
     - vars/config.yml
     - vars/vm_setting.yml

--- a/tasks/kvm_host/install-pkg.yml
+++ b/tasks/kvm_host/install-pkg.yml
@@ -14,3 +14,10 @@
       - tar
       - unzip
     state: latest
+
+- name: install ngxinx-mod-stream for RHEL9.0+
+  dnf:
+    name:
+      - nginx-mod-stream
+    state: latest
+  when: ansible_distribution == "RedHat" and ansible_distribution_major_version | int >= 9


### PR DESCRIPTION
For more details, see #49 

Considering that both `main.yaml` and `main-minimal.yaml` are typically executed against a single node, I believe the performance impact caused by having `gather_facts: yes` can be overlooked.

